### PR TITLE
Friendly url

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -62,7 +62,7 @@ import { PadContainerComponent } from './components/pad/pad-container/pad-contai
 const appRoutes: Routes = [
   { path: '', component: LandingComponent },
   { path: 'home', component: HomeComponent },
-  { path: 'pad/:id', component: PadComponent },
+  { path: 'pad/:name', component: PadComponent },
   { path: 'login', component: LoginComponent },
   { path: '**', component: NotFoundComponent }
 ];

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -43,8 +43,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   launchPad() {
-    this.swellService.getObject(this.padid.value)
+    let name = this.padid.value;
+    this.swellService.getObject(name)
     .then( object => {
+      this.swellService.setObjectName(object.id, name)
       this.router.navigate(['/pad', object.id]);
     })
     .catch( err => {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -47,7 +47,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.swellService.getObject(name)
     .then( object => {
       this.swellService.setObjectName(object.id, name)
-      this.router.navigate(['/pad', object.id]);
+      this.router.navigate(['/pad', name]);
     })
     .catch( err => {
       this.launchError = true;

--- a/src/app/components/pad/pad.component.html
+++ b/src/app/components/pad/pad.component.html
@@ -2,7 +2,7 @@
     <button mat-icon-button (click)="sideDrawer.toggle()">
       <mat-icon>menu</mat-icon>
     </button>    
-    <h1 class="example-app-name">Pad {{object?.id}}</h1>
+    <h1 class="example-app-name">Pad {{name}}</h1>
 </mat-toolbar>
 
 

--- a/src/app/components/pad/pad.component.ts
+++ b/src/app/components/pad/pad.component.ts
@@ -15,7 +15,7 @@ export class PadComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private objectSubscription: Subscription;
   object: any;
-
+  name: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -29,7 +29,8 @@ export class PadComponent implements OnInit, OnDestroy, AfterViewInit {
     });
 
     this.route.paramMap.subscribe( params => {
-      this.padService.init(params.get('id'));
+      this.name = params.get('name');
+      this.padService.init(this.name);
     });
   }
 

--- a/src/app/services/pad.service.ts
+++ b/src/app/services/pad.service.ts
@@ -42,25 +42,32 @@ export class PadService {
    * with this service. Hence, changes in session would happen
    * after destroying the view and cleaning the service.
    *
-   * @param objectId
+   * @param name
    */
-  init(objectId) {
+  init(name) {
+    // get the id from the name
+    this.swellService.getObjectNames(name)
+    .then( response => {
+      let names_json = JSON.parse(JSON.stringify(response));
+      let objectId = names_json['waveId']['domain'].concat('/').concat(names_json['waveId']['id']);
 
-    if (this.editor.hasDocument()) {
-      this.editor.clean();
-    }
+      if (this.editor.hasDocument()) {
+        this.editor.clean();
+      }
 
-    if (this.session) {
-      this.loadObject(objectId);
-    } else {
-      // we must wait for the swell session
-      this.swellService.session$.pipe(first( val => val != null))
-      .subscribe(session => {
-          this.session = session;
-          this.loadObject(objectId);
-      });
+      if (this.session) {
+        this.loadObject(objectId);
+      } else {
+        // we must wait for the swell session
+        this.swellService.session$.pipe(first( val => val != null))
+        .subscribe(session => {
+            this.session = session;
+            this.loadObject(objectId);
+        });
 
-    }
+      }
+
+    });
 
   }
 

--- a/src/app/services/swell.service.ts
+++ b/src/app/services/swell.service.ts
@@ -147,6 +147,14 @@ export class SwellService  {
     });
   }
 
+  setObjectName(objectId, name) {
+    this.api.setObjectName(
+      {
+        id: objectId,
+        name: name
+      })
+  }
+
 
   /**
    * Propagate session info

--- a/src/app/services/swell.service.ts
+++ b/src/app/services/swell.service.ts
@@ -155,6 +155,11 @@ export class SwellService  {
       })
   }
 
+  getObjectNames(name) {
+    return this.api.getObjectNames({ name: name })
+             .then( response => { return response } );
+  }
+
 
   /**
    * Propagate session info


### PR DESCRIPTION
Align pad URL with pad title. For that it was needed to:
 
- Save the pad title when creating it
- Rename the paramether in the route fron `id` to `name`
- Use the name in the route to call `getObjectNames` which allow us to get the id
- Some ugly parsing to get the id, due to the format of the response. See: https://github.com/SwellRT/jetpad/issues/1#issuecomment-404864387 :see_no_evil: 